### PR TITLE
ci: fix PR & push event triggers

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,5 +1,9 @@
 name: Lint Awesome List
-on: [pull_request, push]
+on:
+    pull_request:
+    push:
+        branches:
+            - main
 
 jobs:
     awesome-lint:


### PR DESCRIPTION
Fix event triggers for CI so Push events only trigger on main branch and PRs only have a single set of events from the PR event.