### PR TITLE
Rename Firecode to Firewalk

### DIFF
--- a/readme-ru.md
+++ b/readme-ru.md
@@ -149,7 +149,7 @@
 - 🔌 [Free Product Analytics with Firebase + BigQuery + Rakam](https://rakam.io/blog/free-product-analytics-with-firebase---bigquery---rakam/) - Как выполнить поведенческий анализ и анализ сегментации данных событий Firebase через BigQuery Export и Rakam.
 - 🔌 [Firestore Queue System](https://github.com/sbarbat/firestore-queuer) - Простая система очередей с использованием Firestore и Cloud Functions.
 - 🔌 [Pyrebase](https://github.com/thisbejim/Pyrebase) - Простая обертка на python для Firebase API.
-- 🔌 [Firecode](https://github.com/kafkas/firecode) - Легкая, быстрая и экономичная библиотека для обхода коллекций для Firestore и Node.js.
+- 🔌 [Firewalk](https://github.com/kafkas/firewalk) - Легкая, быстрая и экономичная библиотека для обхода коллекций для Firestore и Node.js.
 
 ## Интерфейс комадной строки и редактор
 

--- a/readme.md
+++ b/readme.md
@@ -148,7 +148,7 @@ Translations: [🇬🇧 en](readme.md) · [🇰🇷 ko](readme-ko.md) · [🇷�
 - 🔌 [Free Product Analytics with Firebase + BigQuery + Rakam](https://rakam.io/blog/free-product-analytics-with-firebase---bigquery---rakam/) - How to do behavioral & segmentation analysis on Firebase event data via BigQuery Export and Rakam.
 - 🔌 [Firestore Queue System](https://github.com/sbarbat/firestore-queuer) - Simple queue system using Firestore and Cloud Functions.
 - 🔌 [Pyrebase](https://github.com/thisbejim/Pyrebase) - A simple python wrapper for the Firebase API.
-- 🔌 [Firecode](https://github.com/kafkas/firecode) - A light, fast, and memory-efficient collection traversal library for Firestore and Node.js.
+- 🔌 [Firewalk](https://github.com/kafkas/firewalk) - A light, fast, and memory-efficient collection traversal library for Firestore and Node.js.
 
 ## CLI & Editor
 


### PR DESCRIPTION
[Firecode](https://github.com/kafkas/firecode) has been renamed to [Firewalk](https://github.com/kafkas/firewalk)!